### PR TITLE
[dispatch] Publish blog post: Factory Control Plane for AI Agents

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -231,6 +231,14 @@
     </header>
 
     <section class="posts">
+      <a href="blog/dispatch-factory-dashboard.html" class="post-card">
+        <h2>I Built a Factory Control Plane for AI Agents in One Afternoon</h2>
+        <div class="post-meta">
+          <span>March 22, 2026</span>
+          <span class="post-tag">AI Workflows</span><span class="post-tag">Claude Code</span><span class="post-tag">Projects</span>
+        </div>
+        <p class="post-excerpt">I've been running AI coding agents overnight for months with no visibility into what's happening. One afternoon, some wine, and a throwaway mockup later — I had a full ops dashboard with live terminal streaming.</p>
+      </a>
       <a href="blog/compostable-patterns.html" class="post-card">
         <h2>Stop Getting Attached to Your AI Tooling</h2>
         <div class="post-meta">

--- a/blog/dispatch-factory-dashboard.html
+++ b/blog/dispatch-factory-dashboard.html
@@ -1,0 +1,363 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; style-src 'self' 'unsafe-inline';">
+  <link rel="icon" type="image/svg+xml" href="../favicon.svg">
+  <link rel="icon" type="image/png" sizes="32x32" href="../assets/favicon/favicon-32.png">
+  <!-- UPDATE: Title for this post -->
+  <title>I Built a Factory Control Plane for AI Agents in One Afternoon – Konrad Odell</title>
+  <style>
+    :root {
+        --bg-primary: #0d1117;
+        --bg-secondary: #161b22;
+        --bg-tertiary: #21262d;
+        --text-primary: #c9d1d9;
+        --text-secondary: #8b949e;
+        --text-accent: #58a6ff;
+        --text-highlight: #7ee787;
+        --border-color: #30363d;
+        --hover-bg: #1c2128;
+        --gradient-1: #58a6ff;
+        --gradient-2: #7ee787;
+        --shadow-color: rgba(0, 0, 0, 0.3);
+        --transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+        --font-size-base: clamp(16px, 2vw, 18px);
+        --container-max-width: min(90vw, 700px);
+    }
+
+    [data-theme="light"] {
+        --bg-primary: #ffffff;
+        --bg-secondary: #f6f8fa;
+        --bg-tertiary: #f0f3f6;
+        --text-primary: #24292e;
+        --text-secondary: #586069;
+        --text-accent: #0366d6;
+        --text-highlight: #28a745;
+        --border-color: #e1e4e8;
+        --hover-bg: #f3f4f6;
+        --gradient-1: #0366d6;
+        --gradient-2: #28a745;
+        --shadow-color: rgba(0, 0, 0, 0.1);
+    }
+
+    @media (prefers-color-scheme: light) {
+        :root:not([data-theme]) {
+            --bg-primary: #ffffff;
+            --bg-secondary: #f6f8fa;
+            --bg-tertiary: #f0f3f6;
+            --text-primary: #24292e;
+            --text-secondary: #586069;
+            --text-accent: #0366d6;
+            --text-highlight: #28a745;
+            --border-color: #e1e4e8;
+            --hover-bg: #f3f4f6;
+            --gradient-1: #0366d6;
+            --gradient-2: #28a745;
+            --shadow-color: rgba(0, 0, 0, 0.1);
+        }
+    }
+
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+
+    body {
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+        font-size: var(--font-size-base);
+        line-height: 1.6;
+        color: var(--text-primary);
+        background-color: var(--bg-primary);
+        transition: var(--transition);
+        min-height: 100vh;
+    }
+
+    .container {
+        width: var(--container-max-width);
+        margin: 0 auto;
+        padding: clamp(40px, 8vh, 80px) clamp(20px, 4vw, 40px);
+    }
+
+    header { margin-bottom: 2rem; }
+
+    .back-link {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        color: var(--text-secondary);
+        text-decoration: none;
+        font-size: 0.9rem;
+        margin-bottom: 1.5rem;
+        transition: var(--transition);
+    }
+
+    .back-link:hover { color: var(--text-accent); }
+
+    h1 {
+        font-size: clamp(1.8rem, 5vw, 2.5rem);
+        font-weight: 700;
+        letter-spacing: -0.5px;
+        color: var(--text-primary);
+        line-height: 1.3;
+    }
+
+    .post-meta {
+        margin-top: 1rem;
+        font-size: 0.9rem;
+        color: var(--text-secondary);
+        display: flex;
+        gap: 1rem;
+        flex-wrap: wrap;
+    }
+
+    .post-tag {
+        background: var(--bg-tertiary);
+        padding: 2px 8px;
+        border-radius: 4px;
+        font-size: 0.8rem;
+    }
+
+    article {
+        margin-top: 2rem;
+    }
+
+    article h2 {
+        font-size: 1.4rem;
+        color: var(--text-primary);
+        margin: 2rem 0 1rem;
+        padding-bottom: 0.5rem;
+        border-bottom: 1px solid var(--border-color);
+    }
+
+    article h3 {
+        font-size: 1.15rem;
+        color: var(--text-accent);
+        margin: 1.5rem 0 0.75rem;
+    }
+
+    article p {
+        color: var(--text-secondary);
+        margin-bottom: 1rem;
+        line-height: 1.8;
+    }
+
+    article ul, article ol {
+        margin: 1rem 0 1rem 1.5rem;
+        color: var(--text-secondary);
+    }
+
+    article li { margin-bottom: 0.5rem; }
+
+    article a {
+        color: var(--text-accent);
+        text-decoration: none;
+    }
+
+    article a:hover { text-decoration: underline; }
+
+    article code {
+        background: var(--bg-tertiary);
+        padding: 2px 6px;
+        border-radius: 4px;
+        font-size: 0.9em;
+        font-family: 'SF Mono', Monaco, Consolas, monospace;
+    }
+
+    article pre {
+        background: var(--bg-secondary);
+        border: 1px solid var(--border-color);
+        border-radius: 8px;
+        padding: 1rem;
+        overflow-x: auto;
+        margin: 1rem 0;
+    }
+
+    article pre code {
+        background: none;
+        padding: 0;
+    }
+
+    article blockquote {
+        border-left: 3px solid var(--text-accent);
+        padding-left: 1rem;
+        margin: 1rem 0;
+        color: var(--text-secondary);
+        font-style: italic;
+    }
+
+    article img {
+        max-width: 100%;
+        border-radius: 8px;
+        margin: 1rem 0;
+        border: 1px solid var(--border-color);
+    }
+
+    article table {
+        width: 100%;
+        border-collapse: collapse;
+        margin: 1rem 0;
+        font-size: 0.95em;
+    }
+
+    article th, article td {
+        padding: 0.75rem 1rem;
+        text-align: left;
+        border-bottom: 1px solid var(--border-color);
+    }
+
+    article th {
+        background: var(--bg-tertiary);
+        font-weight: 600;
+        color: var(--text-primary);
+    }
+
+    article td {
+        color: var(--text-secondary);
+    }
+
+    article tr:hover td {
+        background: var(--hover-bg);
+    }
+
+    .theme-toggle {
+        position: fixed;
+        top: 20px;
+        right: 20px;
+        background: var(--bg-secondary);
+        border: 1px solid var(--border-color);
+        cursor: pointer;
+        font-size: 1.2rem;
+        color: var(--text-secondary);
+        padding: 10px;
+        border-radius: 50%;
+        box-shadow: 0 2px 8px var(--shadow-color);
+        transition: var(--transition);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 44px;
+        height: 44px;
+        z-index: 1000;
+    }
+
+    .theme-toggle:hover {
+        background: var(--hover-bg);
+        color: var(--text-accent);
+        transform: scale(1.1);
+    }
+
+    *:focus-visible {
+        outline: 3px solid var(--text-accent);
+        outline-offset: 3px;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        *, *::before, *::after {
+            animation-duration: 0.01ms !important;
+            transition-duration: 0.01ms !important;
+        }
+    }
+  </style>
+</head>
+<body>
+  <button class="theme-toggle" aria-label="Toggle theme">
+    <svg width="24" height="24" fill="none" viewBox="0 0 24 24" stroke="currentColor" class="sun-icon">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/>
+    </svg>
+    <svg width="24" height="24" fill="none" viewBox="0 0 24 24" stroke="currentColor" class="moon-icon" style="display: none;">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/>
+    </svg>
+  </button>
+
+  <main class="container">
+    <header>
+      <a href="../blog.html" class="back-link">
+        <svg width="16" height="16" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"/>
+        </svg>
+        Back to all posts
+      </a>
+      <!-- UPDATE: Post title -->
+      <h1>I Built a Factory Control Plane for AI Agents in One Afternoon</h1>
+      <div class="post-meta">
+        <!-- UPDATE: Date -->
+        <span>March 22, 2026</span>
+        <!-- UPDATE: Tags -->
+        <span class="post-tag">AI Workflows</span><span class="post-tag">Claude Code</span><span class="post-tag">Projects</span>
+      </div>
+    </header>
+
+    <article>
+      <p>I&rsquo;ve been running AI coding agents overnight for months. Claude Code workers churn through tickets while I sleep — planning, coding, reviewing, deploying. A 7-phase pipeline handles the whole SDLC autonomously.</p>
+<p>But I had no dashboard. Just CLI commands and push notifications. I knew what <em>shipped</em>. I didn&rsquo;t know what was <em>happening</em>.</p>
+<p>Then I read Jess Martin&rsquo;s post about the Software Factory pattern, and something clicked.</p>
+<h2 id="the-pattern">The Pattern</h2>
+<p>Martin describes three layers of alternating determinism:</p>
+<pre><code>Non-deterministic: Factory Operator (monitors, unblocks, fixes)
+  └─ Deterministic: Workflow Pipeline (stations, phases, gates)
+       └─ Non-deterministic: LLM Workers (implementation at each station)
+</code></pre>
+<p>The insight: <strong>the deterministic layer isn&rsquo;t scaffolding to discard as models improve. It&rsquo;s the control plane humans need to steer autonomous production.</strong></p>
+<p>I&rsquo;d independently built almost exactly this architecture. My <code>dispatch</code> pipeline has seven phases (Planner → Worker → Reviewer → Verifier → Monitor → Reporter), adaptive error healing, and visual validation. The three-layer pattern was already there.</p>
+<p>What was missing was the <em>surface</em> — the human interaction layer.</p>
+<h2 id="one-afternoon-wine-and-cheese">One Afternoon, Wine, and Cheese</h2>
+<p>So I built it. One session. Here&rsquo;s what happened.</p>
+<p><strong>First</strong>, I had Claude Code generate a throwaway HTML mockup of the ideal control plane — an ops dashboard with assembly-line visualization, ticket flow, and operator controls. None of this code shipped. It was thinking-out-loud in HTML.</p>
+<p><strong>Then</strong> I scaffolded the real thing:
+- FastAPI backend that reads dispatch artifacts from the filesystem
+- React + Vite + Tailwind frontend with pipeline view, ticket creation, and terminal embedding
+- Security baked in from line 1: localhost-only, read-only default, subprocess array args, no telemetry</p>
+<p><strong>The moment it all clicked</strong> was the terminal. Each dispatch worker runs in a named tmux session. I installed <a href="https://github.com/tsl0922/ttyd">ttyd</a> (one binary), wired up the API to spawn <code>ttyd -R</code> per worker, and embedded the terminal in an iframe. Click &ldquo;Attach Terminal&rdquo; and you get a live tmux session streaming in the browser via WebSocket.</p>
+<p>I dispatched a real ticket from the browser, watched it appear in the pipeline view, clicked to attach the terminal, and saw the worker execute. The whole loop worked.</p>
+<h2 id="what-i-learned">What I Learned</h2>
+<p><strong>The throwaway mockup was essential.</strong> Not for code reuse — none of it shipped. But for thinking through what the control plane needed to <em>be</em>. The mockup had a factory floor visualization, operator panel, human controls. It shaped what the real UI focused on.</p>
+<p><strong>Start with the data pipe.</strong> The first thing I tested was whether the backend could read real dispatch artifacts and return sensible state. 365 sessions parsed correctly on the first try. Everything else built on that foundation.</p>
+<p><strong>Security from commit 1, not commit N.</strong> Localhost-only binding, controls disabled by default, terminal read-only. These aren&rsquo;t features to add later — they&rsquo;re constraints that shape every design decision.</p>
+<p><strong>The terminal is the killer feature.</strong> Pipeline state and ticket creation are expected. But watching a live AI worker session stream in your browser? That&rsquo;s the moment it goes from &ldquo;monitoring tool&rdquo; to &ldquo;control plane.&rdquo;</p>
+<h2 id="will-the-pipeline-get-bitter-lessoned">Will the Pipeline Get Bitter Lessoned?</h2>
+<p>Martin asks whether models will eventually handle the entire SDLC as a single agent, making the deterministic pipeline unnecessary.</p>
+<p>After six months of running this overnight, my answer: <strong>the pipeline stays, but for humans, not models.</strong> The LLM might not need the structure. But I need checkpoints to monitor, gates to intervene at, and a surface to steer from. That&rsquo;s not a limitation — it&rsquo;s the interface.</p>
+<p>The factory floor isn&rsquo;t a constraint on the workers. It&rsquo;s the control plane for the operator.</p>
+<h2 id="try-it">Try It</h2>
+<p><a href="https://github.com/konradish/dispatch-factory">dispatch-factory</a> is open source (Apache 2.0). It works with any pipeline that runs workers in tmux sessions and writes JSON artifacts. You don&rsquo;t need my specific <code>dispatch</code> tool — just named tmux sessions and artifact files.</p>
+<pre><code class="language-bash">git clone https://github.com/konradish/dispatch-factory.git
+cd dispatch-factory
+make install
+cp .dispatch-factory.example.toml .dispatch-factory.toml
+# Edit config to point at your artifacts directory
+make dev
+</code></pre>
+<p>The factory is open. Come build on it.</p>
+    </article>
+  </main>
+
+  <script>
+    const themeToggle = document.querySelector('.theme-toggle');
+    const sunIcon = document.querySelector('.sun-icon');
+    const moonIcon = document.querySelector('.moon-icon');
+    const html = document.documentElement;
+
+    function getTheme() {
+      try { return localStorage.getItem('theme'); } catch (e) { return null; }
+    }
+
+    function setTheme(theme) {
+      try { localStorage.setItem('theme', theme); } catch (e) {}
+    }
+
+    const savedTheme = getTheme();
+    if (savedTheme === 'light' || (!savedTheme && window.matchMedia('(prefers-color-scheme: light)').matches)) {
+      html.setAttribute('data-theme', 'light');
+      sunIcon.style.display = 'none';
+      moonIcon.style.display = 'block';
+    }
+
+    themeToggle.addEventListener('click', () => {
+      const isLight = html.getAttribute('data-theme') === 'light';
+      html.setAttribute('data-theme', isLight ? 'dark' : 'light');
+      setTheme(isLight ? 'dark' : 'light');
+      sunIcon.style.display = isLight ? 'block' : 'none';
+      moonIcon.style.display = isLight ? 'none' : 'block';
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Auto-dispatched task.

**Task:** Read the existing blog post draft at .scratch/blog-post.md in the dispatch-factory repo. Polish it for a 'I built this in one afternoon' angle — tighten prose, ensure it reads well, add any missing context. Then create the final post in the blog repo at an appropriate path under konradish.github.io following the existing blog's format/conventions (check existing posts for frontmatter format, naming conventions, and directory structure). Open a PR.

## Worker Report

**Implemented:**
- Read draft from `/mnt/c/projects/dispatch-factory/.scratch/blog-post.md`
- Polished prose for "built this in one afternoon" angle: tightened section headers, trimmed redundant phrasing, improved flow between sections, removed the open-source mention from the security section (kept focus on design constraints), renamed "The 'holy shit' moment" to something more publishable
- Created frontmatter matching existing conventions (date: 2026-03-22, tags array with AI Workflows/Claude Code/Projects, excerpt, slug)
- Published via `uv run --script publish.py` which generated `blog/dispatch-factory-dashboard.html` and updated `blog.html` index

**Already working (pre-existing):**
- Blog publishing pipeline (`publish.py`) — handles markdown→HTML conversion, index card generation, template application
- Blog template (`blog/_template.html`) — dark/light mode, responsive layout, tag rendering
- Blog index page (`blog.html`) — post cards with date ordering

**Verified:**
- `publish.py` ran successfully, generating the HTML post and updating the index
- Post appears at `blog/dispatch-factory-dashboard.html`
- Blog index (`blog.html`) updated with new post card at top

**Test gate:** echo 'no tests' ✓

🤖 Generated by dispatch CLI